### PR TITLE
Migrate RegExp updates from bids-validator

### DIFF
--- a/bids_validator_common/rules/file_level_rules.json
+++ b/bids_validator_common/rules/file_level_rules.json
@@ -14,13 +14,72 @@
                 "inplaneT1",
                 "inplaneT2",
                 "angio",
-                "defacemask",
-                "SWImagandphase"
+                "SWImagandphase",
+                "T2star",
+                "FLASH",
+                "PDmap",
+                "photo"
             ],
             "@@@_anat_ext_@@@" : [
                 "nii.gz",
                 "nii",
                 "json"
+            ]
+        }
+    },
+
+    "anat_defacemask" : {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?anat\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_mod-(?:@@@_anat_suffixes_@@@))?defacemask.(@@@_anat_ext_@@@)$",
+        "tokens" : {
+            "@@@_anat_suffixes_@@@" : [
+                "T1w",
+                "T2w",
+                "T1map",
+                "T2map",
+                "T1rho",
+                "FLAIR",
+                "PD",
+                "PDT2",
+                "inplaneT1",
+                "inplaneT2",
+                "angio",
+                "SWImagandphase",
+                "T2star",
+                "FLASH",
+                "PDmap",
+                "photo"
+            ],
+            "@@@_anat_ext_@@@" : [
+                "nii.gz",
+                "nii"
+            ]
+        }
+    },
+
+    "behavioral" : {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?beh\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:@@@_behavioral_ext_@@@)$",
+        "tokens" : {
+            "@@@_behavioral_ext_@@@" : [
+                "_beh.json",
+                "_beh.tsv",
+                "_events.json",
+                "_events.tsv",
+                "_physio.tsv.gz",
+                "_stim.tsv.gz",
+                "_physio.json",
+                "_stim.json"
+            ]
+        }
+    },
+
+    "cont" : {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?(?:func|beh)\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_recording-[a-zA-Z0-9]+)?(?:@@@_cont_ext_@@@)$",
+        "tokens" : {
+            "@@@_cont_ext_@@@" : [
+                "_physio.tsv.gz",
+                "_stim.tsv.gz",
+                "_physio.json",
+                "_stim.json"
             ]
         }
     },
@@ -42,6 +101,30 @@
         }
     },
 
+    "eeg" : {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?eeg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_eeg.(@@@_eeg_type_@@@)|(@@@_eeg_ext_@@@))$",
+        "tokens" : {
+            "@@@_eeg_type_@@@" : [
+                "vhdr",
+                "vmrk",
+                "eeg",
+                "edf",
+                "bdf",
+                "set",
+                "fdt",
+                "cnt"
+            ],
+            "@@@_eeg_ext_@@@" : [
+                "_events.tsv",
+                "_electrodes.tsv",
+                "_channels.tsv",
+                "_eeg.json",
+                "_coordsystem.json",
+                "_photo.jpg"
+            ]
+        }
+    },
+
     "field_map" : {
         "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?fmap\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:@@@_field_map_type_@@@).(@@@_field_map_ext_@@@)$",
         "tokens" : {
@@ -59,6 +142,23 @@
                 "nii.gz",
                 "nii",
                 "json"
+            ]
+        }
+    },
+
+    "field_map_main_nii" : {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?fmap\\/\\1(_\\2)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_dir-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?_(?:@@@_field_map_type_@@@).(@@@_field_map_ext_@@@)$",
+        "tokens" : {
+            "@@@_field_map_type_@@@" : [
+                "phasediff",
+                "phase1",
+                "phase2",
+                "fieldmap",
+                "epi"
+            ],
+            "@@@_field_map_ext_@@@" : [
+                "nii.gz",
+                "nii"
             ]
         }
     },
@@ -85,21 +185,6 @@
 
     },
 
-    "behavioral" : {
-        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?beh\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:@@@_behavioral_ext_@@@)$",
-        "tokens" : {
-            "@@@_behavioral_ext_@@@" : [
-                "_beh.json",
-                "_events.json",
-                "_events.tsv",
-                "_physio.tsv.gz",
-                "_stim.tsv.gz",
-                "_physio.json",
-                "_stim.json"
-            ]
-        }
-    },
-
     "func_bold" : {
         "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?func\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_echo-[0-9]+)?(?:@@@_func_bold_ext_@@@)$",
         "tokens" : {
@@ -112,15 +197,78 @@
         }
     },
 
-    "cont" : {
-        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?(?:func|beh)\\/\\1(_\\2)?_task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_recording-[a-zA-Z0-9]+)?(?:@@@_cont_ext_@@@)$",
+    "ieeg" : {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?ieeg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(?:_space-[a-zA-Z0-9]+)?(_ieeg.(@@@_ieeg_type_@@@)|(@@@_ieeg_ext_@@@))$",
         "tokens" : {
-            "@@@_cont_ext_@@@" : [
-                "_physio.tsv.gz",
-                "_stim.tsv.gz",
-                "_physio.json",
-                "_stim.json"
+            "@@@_ieeg_type_@@@" : [
+                "edf",
+                "vhdr",
+                "vmrk",
+                "dat"
+            ],
+            "@@@_ieeg_ext_@@@" : [
+                "_events.tsv",
+                "_electrodes.tsv",
+                "_channels.tsv",
+                "_ieeg.json",
+                "_coordsystem.json",
+                "_photo.jpg"
             ]
         }
+    },
+
+    "meg" : {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?meg\\/\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_part-[0-9]+)?(_meg(@@@_meg_type_@@@\\/.*|\\/.*)|(@@@_meg_ext_@@@))$",
+        "tokens" : {
+            "@@@_meg_type_@@@" : [
+                ".fif",
+                ".ds"
+            ],
+            "@@@_meg_ext_@@@" : [
+                "_events.tsv",
+                "_channels.tsv",
+                "_meg.json",
+                "_coordsystem.json",
+                "_photo.jpg",
+                "_headshape.pos"
+            ]
+        }
+    },
+
+    "modalities" : {
+        "regexp" : "^.*\\.(?:@@_modalities_ext_@@)$",
+        "tokens" : {
+            "@@_modalities_ext_@@" : [
+                "nii",
+                "nii.gz",
+                "fif",
+                "fif.gz",
+                "sqd",
+                "con",
+                "kdf",
+                "chn",
+                "trg",
+                "raw",
+                "raw.mhf",
+                "eeg",
+                "vhdr",
+                "vmrk",
+                "edf",
+                "cnt",
+                "bdf",
+                "set",
+                "fdt",
+                "dat",
+                "nwb",
+                "tdat",
+                "tidx",
+                "tmet"
+            ]
+        }
+    },
+
+    "stimuli" : {
+        "regexp" : "^\\/(?:stimuli)\\/(?:.*)$"
     }
+
 }

--- a/bids_validator_common/rules/session_level_rules.json
+++ b/bids_validator_common/rules/session_level_rules.json
@@ -53,5 +53,47 @@
                 "bvec"
             ]
         }
-    }
+    },
+
+    "meg_ses" :     {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(@@@_meg_ses_type_@@@)$",
+        "tokens" : {
+            "@@@_meg_ses_type_@@@" : [
+                "_events.tsv",
+                "_channels.tsv",
+                "_meg.json",
+                "_coordsystem.json",
+                "_photo.jpg",
+                "_headshape.pos"
+            ]
+        }
+    },
+
+    "eeg_ses" :     {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(@@@_eeg_ses_type_@@@)$",
+        "tokens" : {
+            "@@@_anat_eeg_type_@@@" : [
+                "_events.tsv",
+                "_channels.tsv",
+                "_eeg.json",
+                "_coordsystem.json",
+                "_photo.jpg"
+            ]
+        }
+    },
+
+    "ieeg_ses" :     {
+        "regexp" : "^\\/(sub-[a-zA-Z0-9]+)\\/(?:(ses-[a-zA-Z0-9]+)\\/)?\\1(_\\2)?(?:_task-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:_space-[a-zA-Z0-9]+)?(@@@_ieeg_ses_type_@@@)$",
+        "tokens" : {
+            "@@@_ieeg_ses_type_@@@" : [
+                "_events.tsv",
+                "_channels.tsv",
+                "_electrodes.tsv",
+                "_ieeg.json",
+                "_coordsystem.json",
+                "_photo.jpg",
+                "_headshape.pos"
+            ]
+        }
+    }    
 }

--- a/bids_validator_common/rules/top_level_rules.json
+++ b/bids_validator_common/rules/top_level_rules.json
@@ -16,7 +16,7 @@
 
     "anat_top" :
     {
-        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+_)?(@@@_anat_suffixes_@@@).json$",
+        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(@@@_anat_suffixes_@@@).json$",
         "tokens" : {
             "@@@_anat_suffixes_@@@" : [
                 "T1w",
@@ -30,15 +30,18 @@
                 "inplaneT1",
                 "inplaneT2",
                 "angio",
-                "defacemask",
-                "SWImagandphase"
+                "SWImagandphase",
+                "T2star",
+                "FLASH",
+                "PDmap",
+                "photo"
             ]
         }
     },
 
     "dwi_top" :
     {
-        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(?:_)?dwi.(?:@@@_dwi_top_ext_@@@)$",
+        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?dwi.(?:@@@_dwi_top_ext_@@@)$",
         "tokens" : {
             "@@@_dwi_top_ext_@@@" : [
                 "json",
@@ -47,19 +50,55 @@
             ]
         }
     },
-
+    "eeg_top" :
+    {
+        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:@@@_eeg_top_ext_@@@)$",
+        "tokens" : {
+            "@@@_eeg_top_ext_@@@" : [
+                "_eeg.json",
+                "_channels.tsv",
+                "_photo.jpg",
+                "_coordsystem.json"
+            ]
+        }
+    },
+    "ieeg_top" :
+    {
+        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:@@@_ieeg_top_ext_@@@)$",
+        "tokens" : {
+            "@@@_ieeg_top_ext_@@@" : [
+                "_ieeg.json",
+                "_channels.tsv",
+                "_electrodes.tsv",
+                "_photo.jpg",
+                "_coordsystem.json"
+            ]
+        }
+    },
+    "meg_top" :
+    {
+        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?task-[a-zA-Z0-9]+(?:_acq-[a-zA-Z0-9]+)?(?:_proc-[a-zA-Z0-9]+)?(?:@@@_meg_top_ext_@@@)$",
+        "tokens" : {
+            "@@@_meg_top_ext_@@@" : [
+                "_meg.json",
+                "_channels.tsv",
+                "_photo.jpg",
+                "_coordsystem.json"
+            ]
+        }
+    },
     "multi_dir_fieldmap" :
     {
-        "regexp" : "^\\/(?:dir-[a-zA-Z0-9]+)_epi.json$"
+        "regexp" : "^\\/(?:acq-[a-zA-Z0-9]+_)?(?:dir-[a-zA-Z0-9]+_)epi.json$"
     },
 
     "other_top_files" :
     {
-        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+)?(?:task-[a-zA-Z0-9]+_)?(?:_acq-[a-zA-Z0-9]+)?(?:_rec-[a-zA-Z0-9]+)?(?:_run-[0-9]+)?(@@@_other_top_files_ext_@@@)$",
+        "regexp" : "^\\/(?:ses-[a-zA-Z0-9]+_)?(?:recording-[a-zA-Z0-9]+_)?(?:task-[a-zA-Z0-9]+_)?(?:acq-[a-zA-Z0-9]+_)?(?:rec-[a-zA-Z0-9]+_)?(?:run-[0-9]+_)?(@@@_other_top_files_ext_@@@)$",
         "tokens" : {
             "@@@_other_top_files_ext_@@@" : [
-                "_physio.json",
-                "_stim.json"
+                "physio.json",
+                "stim.json"
             ]
         }
     }


### PR DESCRIPTION
Updated RegExps to match tested RegExps in bids-validator so that bids-validator-common can become source of truth for bids-validator. 